### PR TITLE
feat: Add Meter consumption API

### DIFF
--- a/examples/meterconsumption/main.go
+++ b/examples/meterconsumption/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"octogo"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		log.Println("Warning: Error loading .env file, falling back to system environment variables")
+	}
+
+	apiKey := os.Getenv("OCTOPUS_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OCTOPUS_API_KEY environment variable is required")
+	}
+
+	mpan := os.Getenv("ELECTRIC_MPAN")
+	if mpan == "" {
+		log.Fatal("ELECTRIC_MPAN environment variable is required")
+	}
+
+	serialNumber := os.Getenv("ELECTRIC_SERIAL_NUMBER")
+	if serialNumber == "" {
+		log.Fatal("ELECTRIC_SERIAL_NUMBER environment variable is required")
+	}
+
+	client := octogo.NewClient(apiKey)
+	ctx := context.Background()
+
+	fmt.Printf("Fetching consumption details")
+
+	order := "-period"
+	page_size := 10
+	consumption, resp, err := client.Meter.GetConsumption(ctx, mpan, serialNumber, &octogo.ConsumptionOptions{
+		OrderBy:  &order,
+		PageSize: &page_size,
+	})
+	if err != nil {
+		log.Fatalf("Error fetching consumption details: %v", err)
+	}
+
+	fmt.Printf("HTTP Status: %s\n", resp.Status)
+	if resp.StatusCode == http.StatusOK {
+		fmt.Printf("Consumption Details:\n")
+		fmt.Printf("  Total Readings: %d\n", consumption.Count)
+		if len(consumption.Results) > 0 {
+			for i := 0; i < len(consumption.Results); i++ {
+				reading := consumption.Results[i]
+				fmt.Printf("    %d. Consumption: %.3f kWh, Period: %s to %s\n",
+					i+1, reading.Consumption,
+					reading.IntervalStart.Format("2006-01-02 15:04:05"),
+					reading.IntervalEnd.Format("2006-01-02 15:04:05"))
+			}
+		}
+	} else {
+		fmt.Printf("API returned status code: %d\n", resp.StatusCode)
+	}
+}

--- a/meter.go
+++ b/meter.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 const endpointBasePath = "v1/electricity-meter-points"
 
 type MeterService interface {
 	GetElectricityMeter(ctx context.Context, mpan string) (*Meter, *Response, error)
+	GetConsumption(ctx context.Context, mpan, serialNumber string, opts *ConsumptionOptions) (*ConsumptionResponse, *Response, error)
 }
 
 type Meter struct {
@@ -19,6 +21,29 @@ type Meter struct {
 	ProfileClass int8   `json:"profile_class"`
 }
 
+type ConsumptionReading struct {
+	Consumption   float64   `json:"consumption"`
+	IntervalStart time.Time `json:"interval_start"`
+	IntervalEnd   time.Time `json:"interval_end"`
+}
+
+type ConsumptionResponse struct {
+	Count    int                  `json:"count"`
+	Next     *string              `json:"next"`
+	Previous *string              `json:"previous"`
+	Results  []ConsumptionReading `json:"results"`
+}
+
+type ConsumptionOptions struct {
+	PeriodFrom *time.Time
+	PeriodTo   *time.Time
+	PageSize   *int
+	Page       *int
+	OrderBy    *string
+	GroupBy    *string
+}
+
+// MeterServiceOp handles operations on electricity meters
 type MeterServiceOp struct {
 	client *Client
 }
@@ -31,26 +56,77 @@ func (s *MeterServiceOp) GetElectricityMeter(ctx context.Context, mpan string) (
 	return s.get(ctx, mpan)
 }
 
-func (s *MeterServiceOp) get(ctx context.Context, ID interface{}) (*Meter, *Response, error) {
-	path := fmt.Sprintf("%s/%v", endpointBasePath, ID)
+func (s *MeterServiceOp) GetConsumption(ctx context.Context, mpan, serialNumber string, opts *ConsumptionOptions) (*ConsumptionResponse, *Response, error) {
+	return s.getConsumption(ctx, mpan, serialNumber, opts)
+}
 
-	// Build the full URL
+func (s *MeterServiceOp) get(ctx context.Context, id string) (*Meter, *Response, error) {
+	path := fmt.Sprintf("%s/%s", endpointBasePath, id)
+
 	u, err := url.Parse(path)
 	if err != nil {
 		return nil, nil, err
 	}
 	fullURL := s.client.BaseUrl.ResolveReference(u)
 
-	// Create the HTTP request
 	req, err := http.NewRequest(http.MethodGet, fullURL.String(), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meter := new(Meter)
+	meter := &Meter{}
 	resp, err := s.client.Do(ctx, req, meter)
 	if err != nil {
 		return nil, resp, err
 	}
 	return meter, resp, nil
+}
+
+func (s *MeterServiceOp) getConsumption(ctx context.Context, mpan, serialNumber string, opts *ConsumptionOptions) (*ConsumptionResponse, *Response, error) {
+	path := fmt.Sprintf("%s/%s/meters/%s/consumption/", endpointBasePath, mpan, serialNumber)
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add query parameters if options are provided
+	if opts != nil {
+		query := u.Query()
+
+		if opts.PeriodFrom != nil {
+			query.Set("period_from", opts.PeriodFrom.Format(time.RFC3339))
+		}
+		if opts.PeriodTo != nil {
+			query.Set("period_to", opts.PeriodTo.Format(time.RFC3339))
+		}
+		if opts.PageSize != nil {
+			query.Set("page_size", fmt.Sprintf("%d", *opts.PageSize))
+		}
+		if opts.Page != nil {
+			query.Set("page", fmt.Sprintf("%d", *opts.Page))
+		}
+		if opts.OrderBy != nil {
+			query.Set("order_by", *opts.OrderBy)
+		}
+		if opts.GroupBy != nil {
+			query.Set("group_by", *opts.GroupBy)
+		}
+
+		u.RawQuery = query.Encode()
+	}
+
+	fullURL := s.client.BaseUrl.ResolveReference(u)
+
+	req, err := http.NewRequest(http.MethodGet, fullURL.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	consumption := &ConsumptionResponse{}
+	resp, err := s.client.Do(ctx, req, consumption)
+	if err != nil {
+		return nil, resp, err
+	}
+	return consumption, resp, nil
 }


### PR DESCRIPTION
This pull request introduces functionality to fetch and display electricity meter consumption data using the Octopus Energy API. Key changes include adding a new CLI application, extending the `MeterService` to support consumption retrieval, and defining new data structures for handling consumption data.

### New CLI Application:
* Created a new CLI application in `examples/meterconsumption/main.go` to fetch and display electricity consumption details. It uses environment variables for configuration and interacts with the Octopus Energy API through the `octogo` client.

### Enhancements to `MeterService`:
* Added a new method `GetConsumption` to the `MeterService` interface and its implementation to fetch electricity consumption data for a specific meter. [[1]](diffhunk://#diff-6e927f05aabc704b2a1bab6402c3cb93c3c079f39712bf7b024101b53caaa9c8R8-R15) [[2]](diffhunk://#diff-6e927f05aabc704b2a1bab6402c3cb93c3c079f39712bf7b024101b53caaa9c8L34-R132)

### New Data Structures:
* Introduced `ConsumptionReading`, `ConsumptionResponse`, and `ConsumptionOptions` structs in `meter.go` to model consumption data, API responses, and query parameters, respectively.